### PR TITLE
BaSP-MR-34: Super admin Test - Put and delete

### DIFF
--- a/src/seeds/super-admins.js
+++ b/src/seeds/super-admins.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
 export default [{
-  _id: new mongoose.Types.ObjectId('635316fe464e1ad6227622e4'),
-  email: 'test@gmail.com',
-  password: 'password123',
+  _id: new mongoose.Types.ObjectId('6466b3610ebbac7a2a1b9f8f'),
+  email: 'princesita2@grumosa.com',
+  password: 'horadeaventura2',
 }];

--- a/src/tests/super-admins.test.js
+++ b/src/tests/super-admins.test.js
@@ -58,6 +58,9 @@ describe('PUT /api/super-admins', () => {
     jest.spyOn(superAdmin, 'findByIdAndUpdate').mockRejectedValue(new Error('Something went wrong'));
     const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
     expect(response.status).toBe(500);
+    expect(response.body.data).toBeUndefined();
+    expect(response.body.message).toEqual({});
+    expect(response.body.error).toBeTruthy();
   });
   test('Invalid ID, return error 400', async () => {
     const response = await request(app).put('/api/super-admins/1234asdawaadw').send();
@@ -103,6 +106,9 @@ describe('DELETE /api/super-admins', () => {
     jest.spyOn(superAdmin, 'findByIdAndDelete').mockRejectedValue(new Error('Something went wrong'));
     const response = await request(app).delete(`/api/super-admins/${superAdminId}`).send();
     expect(response.status).toBe(500);
+    expect(response.body.data).toBeUndefined();
+    expect(response.body.message).toEqual({});
+    expect(response.body.error).toBeTruthy();
   });
   test('Invalid ID, return error 400', async () => {
     const response = await request(app).delete('/api/super-admins/1234asdawaadw').send();

--- a/src/tests/super-admins.test.js
+++ b/src/tests/super-admins.test.js
@@ -1,9 +1,8 @@
-// Basic test to avoid conflicts
+/* eslint-disable no-underscore-dangle */
 import request from 'supertest';
 import app from '../app';
 import superAdmin from '../models/SuperAdmin';
 import adminSeed from '../seeds/super-admins';
-import SuperAdmin from '../models/SuperAdmin';
 
 beforeEach(async () => {
   await superAdmin.collection.insertMany(adminSeed);
@@ -16,9 +15,7 @@ afterEach(async () => {
 
 const superAdminId = adminSeed[0]._id;
 
-const invalidSuperAdmin = '6561-361#0ebcc@7a2a1b9f'
-
-const notFoundId = '6466b3620ebbac7a2a1b7f8f'
+const notFoundId = '6466b3620ebbac7a2a1b7f8f';
 
 const missingEmailFieldSuperAdmin = {
   _id: '6466b3610ebbac7a2a1b9f8f',
@@ -35,32 +32,49 @@ describe('PUT /api/super-admin', () => {
     const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
     expect(response.status).toBe(200);
     expect(response.body.data).toBeDefined();
-    expect(response.body.message).toBe('Super Admin Updated Successfully!')
-    expect(response.body.error).toBe(false);
+    expect(response.body.message).toBe('Super Admin Updated Successfully!');
+    expect(response.body.error).toBeFalsy();
   });
   test('should not found id, return error 404', async () => {
     const response = await request(app).put(`/api/super-admins/${notFoundId}`).send(putTestSuperAdmin);
     expect(response.status).toBe(404);
     expect(response.body.data).toBeDefined();
-    expect(response.body.message).toBe('Super Admin could not be Found and updated')
-    expect(response.body.error).toBe(true);
+    expect(response.body.message).toBe('Super Admin could not be Found and updated');
+    expect(response.body.error).toBeTruthy();
   });
-  test('missing email, return 400', async () => {
+  test('missing email, return error 400', async () => {
     const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(missingEmailFieldSuperAdmin);
     expect(response.status).toBe(400);
     expect(response.body.data).toBeUndefined();
-    expect(response.body.message).toBe('There was an error: \"email\" is required');
-    expect(response.body.error).toBe(true);
+    expect(response.body.message).toBe('There was an error: "email" is required');
+    expect(response.body.error).toBeTruthy();
   });
-  test('Should respond server error, return 500', async () => {
-    jest.spyOn(SuperAdmin, 'findByIdAndUpdate').mockRejectedValue(new Error('Something went wrong'));
+  test('Should respond server error, return status 500', async () => {
+    jest.spyOn(superAdmin, 'findByIdAndUpdate').mockRejectedValue(new Error('Something went wrong'));
     const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
     expect(response.status).toBe(500);
   });
 });
 
-// describe('DELETE /api/super-admin', () => {
-//   test('Should delete one super admin', async () => {
-
-//   });
-// });
+describe('DELETE /api/super-admin', () => {
+  test('Should delete one super admins, return status 200', async () => {
+    const response = await request(app).delete(`/api/super-admins/${superAdminId}`).send();
+    expect(response.status).toBe(200);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.message).toBe('Super Admin Deleted Successfully!');
+    expect(response.body.error).toBeFalsy();
+  });
+  test('Should not be found and delete an super admin, return error 400', async () => {
+    await superAdmin.deleteMany();
+    const response = await request(app).delete(`/api/super-admins/${superAdminId}`).send();
+    expect(response.status).toBe(400);
+    expect(response.body.data).toEqual({});
+    expect(response.body.message).toBe('Super Admin could not be found and deleted!');
+    expect(response.body.error).toBeTruthy();
+  });
+  test('Should respond server error, return status 500', async () => {
+    jest.spyOn(superAdmin, 'findByIdAndDelete').mockRejectedValue(new Error('Something went wrong'));
+    const response = await request(app).delete(`/api/super-admins/${superAdminId}`).send();
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/tests/super-admins.test.js
+++ b/src/tests/super-admins.test.js
@@ -1,5 +1,66 @@
 // Basic test to avoid conflicts
-// REMOVE THIS TEST AND MAKE YOURS!
-test('should pass a basic test', () => {
-  expect(1 + 1).toBe(2);
+import request from 'supertest';
+import app from '../app';
+import superAdmin from '../models/SuperAdmin';
+import adminSeed from '../seeds/super-admins';
+import SuperAdmin from '../models/SuperAdmin';
+
+beforeEach(async () => {
+  await superAdmin.collection.insertMany(adminSeed);
 });
+
+afterEach(async () => {
+  await superAdmin.collection.deleteMany();
+  jest.restoreAllMocks();
+});
+
+const superAdminId = adminSeed[0]._id;
+
+const invalidSuperAdmin = '6561-361#0ebcc@7a2a1b9f'
+
+const notFoundId = '6466b3620ebbac7a2a1b7f8f'
+
+const missingEmailFieldSuperAdmin = {
+  _id: '6466b3610ebbac7a2a1b9f8f',
+  password: 'horadeaventura2',
+};
+
+const putTestSuperAdmin = {
+  email: 'picklerick@morty.com',
+  password: 'rickandmorty2',
+};
+
+describe('PUT /api/super-admin', () => {
+  test('should modify one super admin, return status 200', async () => {
+    const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
+    expect(response.status).toBe(200);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.message).toBe('Super Admin Updated Successfully!')
+    expect(response.body.error).toBe(false);
+  });
+  test('should not found id, return error 404', async () => {
+    const response = await request(app).put(`/api/super-admins/${notFoundId}`).send(putTestSuperAdmin);
+    expect(response.status).toBe(404);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.message).toBe('Super Admin could not be Found and updated')
+    expect(response.body.error).toBe(true);
+  });
+  test('missing email, return 400', async () => {
+    const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(missingEmailFieldSuperAdmin);
+    expect(response.status).toBe(400);
+    expect(response.body.data).toBeUndefined();
+    expect(response.body.message).toBe('There was an error: \"email\" is required');
+    expect(response.body.error).toBe(true);
+  });
+  test('Should respond server error, return 500', async () => {
+    jest.spyOn(SuperAdmin, 'findByIdAndUpdate').mockRejectedValue(new Error('Something went wrong'));
+    const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
+    expect(response.status).toBe(500);
+  });
+});
+
+// describe('DELETE /api/super-admin', () => {
+//   test('Should delete one super admin', async () => {
+
+//   });
+// });

--- a/src/tests/super-admins.test.js
+++ b/src/tests/super-admins.test.js
@@ -27,7 +27,12 @@ const putTestSuperAdmin = {
   password: 'rickandmorty2',
 };
 
-describe('PUT /api/super-admin', () => {
+const missingPasswordFieldSuperAdmin = {
+  _id: '6466b3610ebbac7a2a1b9f8f',
+  email: 'picklerick@morty.com',
+};
+
+describe('PUT /api/super-admins', () => {
   test('should modify one super admin, return status 200', async () => {
     const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
     expect(response.status).toBe(200);
@@ -54,9 +59,31 @@ describe('PUT /api/super-admin', () => {
     const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
     expect(response.status).toBe(500);
   });
+  test('Invalid ID, return error 400', async () => {
+    const response = await request(app).put('/api/super-admins/1234asdawaadw').send();
+    expect(response.status).toBe(400);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.message).toBe('This is not a valid object Id');
+    expect(response.body.error).toBeTruthy();
+  });
+  test('Should not be found and modify a super admin, return error 404', async () => {
+    await superAdmin.deleteMany();
+    const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(putTestSuperAdmin);
+    expect(response.status).toBe(404);
+    expect(response.body.data).toEqual({});
+    expect(response.body.message).toBe('Super Admin could not be Found and updated');
+    expect(response.body.error).toBeTruthy();
+  });
+  test('missing password, return error 400', async () => {
+    const response = await request(app).put(`/api/super-admins/${superAdminId}`).send(missingPasswordFieldSuperAdmin);
+    expect(response.status).toBe(400);
+    expect(response.body.data).toBeUndefined();
+    expect(response.body.message).toBe('There was an error: "password" is required');
+    expect(response.body.error).toBeTruthy();
+  });
 });
 
-describe('DELETE /api/super-admin', () => {
+describe('DELETE /api/super-admins', () => {
   test('Should delete one super admins, return status 200', async () => {
     const response = await request(app).delete(`/api/super-admins/${superAdminId}`).send();
     expect(response.status).toBe(200);
@@ -64,7 +91,7 @@ describe('DELETE /api/super-admin', () => {
     expect(response.body.message).toBe('Super Admin Deleted Successfully!');
     expect(response.body.error).toBeFalsy();
   });
-  test('Should not be found and delete an super admin, return error 400', async () => {
+  test('Should not be found and delete a super admin, return error 400', async () => {
     await superAdmin.deleteMany();
     const response = await request(app).delete(`/api/super-admins/${superAdminId}`).send();
     expect(response.status).toBe(400);
@@ -76,5 +103,19 @@ describe('DELETE /api/super-admin', () => {
     jest.spyOn(superAdmin, 'findByIdAndDelete').mockRejectedValue(new Error('Something went wrong'));
     const response = await request(app).delete(`/api/super-admins/${superAdminId}`).send();
     expect(response.status).toBe(500);
+  });
+  test('Invalid ID, return error 400', async () => {
+    const response = await request(app).delete('/api/super-admins/1234asdawaadw').send();
+    expect(response.status).toBe(400);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.message).toBe('This is not a valid object Id');
+    expect(response.body.error).toBeTruthy();
+  });
+  test('Should not found id, return error 404', async () => {
+    const response = await request(app).delete(`/api/super-admins/${notFoundId}`).send(putTestSuperAdmin);
+    expect(response.status).toBe(400);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.message).toBe('Super Admin could not be found and deleted!');
+    expect(response.body.error).toBeTruthy();
   });
 });


### PR DESCRIPTION
Make the next tests to validate the controllers and validations for Super Admin put and delete.

Put Tests:
-Modify Super admin.
-Not found ID.
-Missing Email.
-Invalid ID.
-Cant found and modify super admin.
-Missing Password.
-Not server response.

Delete Tests:
-Delete Super Admin
-Cant found and delete Super Admin.
-Invalid ID.
-Not found ID.
-Not server response.
